### PR TITLE
refactor: create new did registry instance for did operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aries-framework/askar": "0.4.2",
     "@aries-framework/core": "0.4.2",
-    "@ayanworks/polygon-did-registrar": "0.0.16-alpha.5",
+    "@ayanworks/polygon-did-registrar": "0.0.16-alpha.6",
     "@ayanworks/polygon-did-resolver": "0.0.16-alpha.8",
     "@ayanworks/polygon-schema-manager": "0.0.2-alpha.1",
     "did-resolver": "^4.1.0",

--- a/src/PolygonModuleConfig.ts
+++ b/src/PolygonModuleConfig.ts
@@ -4,21 +4,21 @@ import { Buffer } from '@aries-framework/core'
  * PolygonModuleConfigOptions defines the interface for the options of the PolygonModuleConfig class.
  */
 export interface PolygonModuleConfigOptions {
-  rpcUrl: string
-  didContractAddress: string
-  privateKey: Buffer
-  fileServerToken: string
-  schemaManagerContractAddress: string
-  serverUrl: string
+  rpcUrl?: string
+  didContractAddress?: string
+  privateKey?: Buffer
+  fileServerToken?: string
+  schemaManagerContractAddress?: string
+  serverUrl?: string
 }
 
 export class PolygonModuleConfig {
-  public readonly rpcUrl!: string
-  public readonly didContractAddress!: string
-  public readonly privateKey!: Buffer
-  public readonly fileServerToken!: string
-  public readonly schemaManagerContractAddress!: string
-  public readonly serverUrl!: string
+  public readonly rpcUrl: string | undefined
+  public readonly didContractAddress: string | undefined
+  public readonly privateKey: Buffer | undefined
+  public readonly fileServerToken: string | undefined
+  public readonly schemaManagerContractAddress: string | undefined
+  public readonly serverUrl: string | undefined
 
   public constructor({
     didContractAddress,

--- a/src/dids/PolygonDidResolver.ts
+++ b/src/dids/PolygonDidResolver.ts
@@ -10,7 +10,6 @@ import { isValidPolygonDid } from './didPolygonUtil'
 import { Resolver, ResolverRegistry } from 'did-resolver'
 
 import { getResolver } from '@ayanworks/polygon-did-resolver'
-import { PolygonLedgerService } from '../ledger'
 
 export class PolygonDidResolver implements DidResolver {
   public readonly supportedMethods = ['polygon']

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// Dids
 export { PolygonDidRegistrar, PolygonDidResolver } from './dids'
 
 export { PolygonLedgerService } from './ledger'
@@ -6,3 +5,5 @@ export { PolygonLedgerService } from './ledger'
 export { PolygonModule } from './PolygonModule'
 
 export { PolygonModuleConfig, PolygonModuleConfigOptions } from './PolygonModuleConfig'
+
+export * from './utils'

--- a/src/ledger/PolygonLedgerService.ts
+++ b/src/ledger/PolygonLedgerService.ts
@@ -3,10 +3,20 @@ import { PolygonDID } from '@ayanworks/polygon-did-registrar'
 import { PolygonSchema } from '@ayanworks/polygon-schema-manager'
 import { PolygonModuleConfig } from '../PolygonModuleConfig'
 
+interface SchemaRegistryConfig {
+  didRegistrarContractAddress: string
+  rpcUrl: string
+  fileServerToken: string
+  privateKey: string
+  schemaManagerContractAddress: string
+  serverUrl: string
+}
+
 @injectable()
 export class PolygonLedgerService {
-  public didRegistry: PolygonDID
-  private schemaRegistry: PolygonSchema
+  private schemaRegistry: PolygonSchema | undefined
+  private rpcUrl: string | undefined
+  private contractAddress: string | undefined
 
   public constructor({
     didContractAddress,
@@ -16,19 +26,19 @@ export class PolygonLedgerService {
     schemaManagerContractAddress,
     serverUrl,
   }: PolygonModuleConfig) {
-    this.didRegistry = new PolygonDID({
-      rpcUrl,
-      contractAddress: didContractAddress,
-      privateKey: privateKey.toString('hex'),
-    })
-    this.schemaRegistry = new PolygonSchema({
-      didRegistrarContractAddress: didContractAddress,
-      rpcUrl,
-      fileServerToken,
-      privateKey: privateKey.toString('hex'),
-      schemaManagerContractAddress,
-      serverUrl,
-    })
+    this.rpcUrl = rpcUrl
+    this.contractAddress = didContractAddress
+
+    if (schemaManagerContractAddress && privateKey && rpcUrl && fileServerToken && serverUrl && didContractAddress) {
+      this.schemaRegistry = new PolygonSchema({
+        didRegistrarContractAddress: didContractAddress,
+        rpcUrl,
+        fileServerToken,
+        privateKey: privateKey.toString('hex'),
+        schemaManagerContractAddress,
+        serverUrl,
+      })
+    }
   }
 
   public async createSchema(
@@ -36,6 +46,12 @@ export class PolygonLedgerService {
     { did, schemaName, schema }: { did: string; schemaName: string; schema: object }
   ) {
     agentContext.config.logger.info(`Creating schema on ledger: ${did}`)
+
+    if (!this.schemaRegistry) {
+      agentContext.config.logger.error(`Schema registry not found`)
+      throw new AriesFrameworkError(`Schema registry not configured. Please check your configuration`)
+    }
+
     const response = await this.schemaRegistry.createSchema(did, schemaName, schema)
     if (!response) {
       agentContext.config.logger.error(`Schema creation failed for did: ${did} and schema: ${schema}`)
@@ -47,6 +63,12 @@ export class PolygonLedgerService {
 
   public async getSchemaByDidAndSchemaId(agentContext: AgentContext, did: string, schemaId: string) {
     agentContext.config.logger.info(`Getting schema from ledger: ${did} and schemaId: ${schemaId}`)
+
+    if (!this.schemaRegistry) {
+      agentContext.config.logger.error(`Schema registry config not found`)
+      throw new AriesFrameworkError(`Schema registry not configured. Please check your configuration`)
+    }
+
     const response = await this.schemaRegistry.getSchemaById(did, schemaId)
 
     if (!response) {
@@ -55,5 +77,39 @@ export class PolygonLedgerService {
     }
     agentContext.config.logger.info(`Got schema from ledger: ${did} and schemaId: ${schemaId}`)
     return response
+  }
+
+  public createDidRegistryInstance(privateKey: string) {
+    if (!this.rpcUrl || !this.contractAddress) {
+      throw new AriesFrameworkError('Ledger config not found')
+    }
+
+    return new PolygonDID({
+      rpcUrl: this.rpcUrl,
+      contractAddress: this.contractAddress,
+      privateKey,
+    })
+  }
+
+  public updateSchemaRegistryInstance({
+    didRegistrarContractAddress,
+    fileServerToken,
+    privateKey,
+    rpcUrl,
+    schemaManagerContractAddress,
+    serverUrl,
+  }: SchemaRegistryConfig) {
+    if (!rpcUrl || !didRegistrarContractAddress || !privateKey || !fileServerToken || !schemaManagerContractAddress) {
+      throw new AriesFrameworkError('Some of the schema registry configs are not provided')
+    }
+
+    this.schemaRegistry = new PolygonSchema({
+      didRegistrarContractAddress,
+      rpcUrl,
+      fileServerToken,
+      privateKey,
+      schemaManagerContractAddress,
+      serverUrl,
+    })
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,0 @@
-import { PolygonDID } from '@ayanworks/polygon-did-registrar'
-
-export const generateSecp256k1KeyPair = async () => {
-  const { privateKey, publicKeyBase58, address } = await PolygonDID.createKeyPair()
-  return { privateKey, publicKeyBase58, address }
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+import { PolygonDID } from '@ayanworks/polygon-did-registrar'
+
+export const generateSecp256k1KeyPair = async () => {
+  const { privateKey, publicKeyBase58, address } = await PolygonDID.createKeyPair()
+  return { privateKey, publicKeyBase58, address }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './utils'

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,6 @@
+import { PolygonDID } from '@ayanworks/polygon-did-registrar'
+
+export const generateSecp256k1KeyPair = async () => {
+  const { privateKey, publicKeyBase58, address } = await PolygonDID.createKeyPair()
+  return { privateKey, publicKeyBase58, address }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
   dependencies:
     static-eval "2.0.2"
 
-"@ayanworks/polygon-did-registrar@0.0.16-alpha.5":
-  version "0.0.16-alpha.5"
-  resolved "https://registry.yarnpkg.com/@ayanworks/polygon-did-registrar/-/polygon-did-registrar-0.0.16-alpha.5.tgz#6c683558eaee2eb42fb136e42d348316613cb71b"
-  integrity sha512-Z3+sBuuivHcuUE3dmT/7zWvoyKFymHzlwQtmhDSKBGHWBxj9gbd681q7m+ph5klHTw9OJH1rZvUTXNtnVtEO1A==
+"@ayanworks/polygon-did-registrar@0.0.16-alpha.6":
+  version "0.0.16-alpha.6"
+  resolved "https://registry.yarnpkg.com/@ayanworks/polygon-did-registrar/-/polygon-did-registrar-0.0.16-alpha.6.tgz#3da40d7e82f367c171781f3b36762d3fd324d526"
+  integrity sha512-dfAFYI+qM5m77VEVxNvvnOL9W11xBVGdzVacNpYPQiVaWTj1XtX+2BCFsVKu8GRWM9NgcUUOZBzErMp32wAgdg==
   dependencies:
     "@ayanworks/polygon-did-registry-contract" "2.0.1-alpha.3"
     "@ethersproject/basex" "^5.7.0"


### PR DESCRIPTION
### Summary

- Updated the polygon module config to make all parameters optional for `holders`
- Updated the did operations to use the private key each time
- Added method to use `updateSchemaRegistryInstance` to update schema registry instance
- Added method to generate key pair for secp256k1 